### PR TITLE
fix makefile; change telnet init

### DIFF
--- a/lib/sys-none/rules.mk
+++ b/lib/sys-none/rules.mk
@@ -69,7 +69,7 @@ $(OBJDIR)/%.o: %.c
 $(OBJDIR)/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
 
-$(OBJCTS): | $(BUILDDIR)
+$(OBJCTS): | $(OBJDIR)
 
 ifeq ($(LINKWITH), GCC)
 %.elf: $(OBJCTS)

--- a/tools/uploader/serflash/serflash.go
+++ b/tools/uploader/serflash/serflash.go
@@ -207,7 +207,7 @@ func fixChecksum(data []byte) {
 
 func UseTelnet(s io.ReadWriter) io.ReadWriter {
 	// doesn't seem to be needed:
-	//s.Write([]byte{Iac, Will, ComPortOpt})
+	s.Write([]byte{Iac, Will, ComPortOpt})
 	return &telnetWrapper{upLink: s, inState: 0}
 }
 


### PR DESCRIPTION
Fixed a target in makefile to ensure that build/obj dir is created.
Re-added telnet negotiation so the esp-link software can detect that the client wants telnet support to reset the microcontroller (it looks at the first characters received on a new connection to determine that).