### PR TITLE
Si70xx driver (T&RH sensor chip)

### DIFF
--- a/explore/1608-forth/flib/i2c/si70xx.fs
+++ b/explore/1608-forth/flib/i2c/si70xx.fs
@@ -1,0 +1,29 @@
+
+: Si7021-RH-conv ( u -- s ) \ converts measured RH to signed int RH
+  125 * 65536 / 6 - ;
+: Si7021-T-conv ( u -- ds) \ converts measured T to fixed point T
+  0 swap	( make it fixed point)
+  72 175 f*	( * 175.72 )
+  0 65536 f/	( wasteful, but who cares )
+  85 46 d-	( - 46.85 )
+  ;
+: Si-RH      $40 i2c-addr $E5 >i2c 2 i2c-xfer i2c>h_inv Si7021-RH-conv ; \ Measure RH (wait)
+: Si-T       $40 i2c-addr $E3 >i2c 2 i2c-xfer i2c>h_inv Si7021-T-conv ;  \ Measure T (wait)
+: Si-lastT   $40 i2c-addr $E0 >i2c 2 i2c-xfer i2c>h_inv Si7021-T-conv ; \ Get T from last RH measurement
+: Si-serial1 ( -- u) \ Gets first 32 bits of serial
+  $40 i2c-addr $FA >i2c $0F >i2c
+  8 i2c-xfer
+  0
+  4 0 do
+    i2c> i2c> drop
+    swap 8 lshift or
+  loop ;
+
+: Si-serial2 ( -- u) \ Gets 2nd 32 bits of serial
+  $40 i2c-addr $FC >i2c $C9 >i2c
+  6 i2c-xfer
+  0
+  2 0 do
+    i2c>h_inv i2c> drop
+    swap 16 lshift or
+  loop ;


### PR DESCRIPTION
Hi,

In testing the I2C interface, I write a small driver for the Silicon Labs Si70xx series of T & RH sensors. Some are becoming quite affordable, and performance is supposed to be really good. It seems that the entire series uses identical algorithms, so that's nice. This driver only implements the basics:
- reading RH (integer)
- reading temperature (fixed point)
- reading temperature that was recorded during last RH measurement (fixed point)
- Get both parts of the serial identification (ignoring CRC checks for now)

best regards,
Joris
