### PR TITLE
Add i2c-xfer for N=1

### DIFF
--- a/explore/1608-forth/flib/stm32f1/i2c.fs
+++ b/explore/1608-forth/flib/stm32f1/i2c.fs
@@ -196,6 +196,7 @@ $40005800 constant I2C2
 	i2c-EV6b                   \ Clear ADDR
 	i2c-stop!                  \ Trigger a stop
 	0 i2c.needstop !
+      endof
       0 of                      ( cnt = 0, probe only )
         i2c-nak? i2c-AF-0 i2c-stop
         0 i2c.needstop !


### PR DESCRIPTION
This should fix #62 by adding i2c-xfer behaviour for N=1.
This was an oversight on my part: I had waited implementing this one because it needed some register twiddling inside EV6. Eventually, I think this is a simple way to solve it.

Would really appreciate some feedback if this works as expected.

Next time, I'll leave whitespace cleanup out of it :-)