### PR TITLE
bme280 sleep mode

### DIFF
--- a/docs/flib/bme280.md
+++ b/docs/flib/bme280.md
@@ -12,7 +12,9 @@ sensor. The SPI mode of this chip is not supported.
 The default initialization using `bme-init` puts the chip into
 continuous conversion mode, which means that it can be read anytime using
 `bme-data`. For low-power operation, `bme-init-sleep` may be used instead
-to leave the chip in sleep mode and set-up for one-shot conversions.
+to leave the chip in sleep mode and set-up for one-shot conversions using
+`bme-convert`.
+
 `bme-calib` must be called once after `bme-init` or `bme-init-sleep`
 to load the chip-specific calibration values.
 

--- a/docs/flib/bme280.md
+++ b/docs/flib/bme280.md
@@ -9,16 +9,40 @@ sensor. The SPI mode of this chip is not supported.
 
 ### API
 
-[defs]: <> (bme-init bme-calib)
+The default initialization using `bme-init` puts the chip into
+continuous conversion mode, which means that it can be read anytime using
+`bme-data`. For low-power operation, `bme-init-sleep` may be used instead
+to leave the chip in sleep mode and set-up for one-shot conversions.
+`bme-calib` must be called once after `bme-init` or `bme-init-sleep`
+to load the chip-specific calibration values.
+
+[defs]: <> (bme-init bme-init-sleep bme-calib)
 ```
-: bme-init ( -- nak )
+: bme-init ( -- nak ) \ init the bme280 into continuous mode
+: bme-init-sleep ( -- nak ) \ init the bme280 into sleep mode
 : bme-calib ( -- )
 ```
+
+To read the last conversion values call `bme-data` and then
+`bme-calc`. The humidity is returned in 1/100th percent of relative
+humidity, the pressure is returned in Pascal, and the temperature is
+returned in 1/100th degrees celsius.
 
 [defs]: <> (bme-data bme-calc)
 ```
 : bme-data ( -- )  \ get a sensor reading from the BME280
 : bme-calc ( -- h p t )  \ convert reading to calibrated values
+```
+
+`bme-convert` performs a one-shot conversion and returns the chip to
+sleep mode.  It returns the number of milliseconds to wait before the
+data can be retrieved.  `bme-sleep` forces the chip to sleep mode. Use
+of the init words to wake it up again.
+
+[defs]: <> (bme-convert bme-sleep)
+```
+: bme-convert ( -- ms ) \ perform a one-shot forced reading, return ms before data is ready
+: bme-sleep ( -- ) \ force bme280 to sleep
 ```
 
 ### Variables


### PR DESCRIPTION
This adds support to keep the bme280 asleep and perform one-shot conversions.