### PR TITLE
Some multitasker and i²c enhancements/fixes

### DIFF
--- a/explore/1608-forth/flib/any/i2c-bb.fs
+++ b/explore/1608-forth/flib/any/i2c-bb.fs
@@ -1,8 +1,8 @@
 \ bit-banged i2c driver
 \ adapted from http://excamera.com/sphinx/article-forth-i2c.html
 \
-\ This driver is master-only and won't support clock stretching.
-\ There has to be a 1..10 kΩ resistor on SDA to pull it up in idle state.
+\ This driver is master-only. It supports clock stretching.
+\ There have to be 1..10 kΩ resistors on SDA and SCL to pull them up to idle state.
 
 [ifndef] SCL  PB6 constant SCL  [then]
 [ifndef] SDA  PB7 constant SDA  [then]
@@ -13,12 +13,16 @@
 0 variable i2c.cnt
 
 : i2c-init ( -- )  \ initialise bit-banged I2C
-  OMODE-PP SCL io-mode!
-  OMODE-OD SDA io-mode!
-;
+  OMODE-OD SCL io-mode!
+  OMODE-OD SDA io-mode! ;
 
 : i2c-half ( -- )  \ half-cycle timing delay for I2C
   [ifdef] I2C.DELAY  I2C.DELAY 0 do loop  [then] inline ;
+
+: SCL-ios! ( -- ) \ raise clock
+  SCL ios! 
+  begin SCL io@ until \ clock stretching to finish
+;
 
 : i2c-start ( -- )  \ with SCL high, change SDA from 1 to 0
   SDA ios! i2c-half SCL ios! i2c-half SDA ioc! i2c-half SCL ioc! ;
@@ -26,9 +30,9 @@
   SDA ioc! i2c-half SCL ios! i2c-half SDA ios! i2c-half ;
 
 : b>i2c ( f -- )  \ send one I2C bit
-  0<> SDA io! i2c-half SCL ios! i2c-half SCL ioc! ;
+  0<> SDA io! i2c-half SCL-ios! i2c-half SCL ioc! ;
 : i2c>b ( -- b )  \ receive one I2C bit
-  SDA ios! i2c-half SCL ios! i2c-half SDA io@ SCL ioc! ;
+  SDA ios! i2c-half SCL-ios! i2c-half SDA io@ SCL ioc! ;
 
 : x>i2c ( b -- nak )  \ send one byte
   8 0 do dup 128 and b>i2c shl loop drop i2c>b ;
@@ -57,7 +61,7 @@
   dup i2c.cnt !  if
     i2c-start i2c.adr @ 1+ i2c.prv ! i2c-flush
   else
-    SCL ios!  \ i2c-stop
+    SCL-ios!  \ i2c-stop
   then
   i2c.nak @
   dup if i2c-stop 0 i2c.cnt ! then  \ ignore reads if we had a nak

--- a/explore/1608-forth/flib/mecrisp/multi-irq.fs
+++ b/explore/1608-forth/flib/mecrisp/multi-irq.fs
@@ -1,0 +1,26 @@
+\ cooperative multitasking w/ interrupts
+
+include multi.fs
+
+\ Most of multi.fs is interrupt safe.
+\ However, if you use an interrupt to wake up your task, this code
+\
+\   need-some-state? if
+\     setup-statechange-irq stop
+\   then
+\
+\ is incorrect: when the interrupt occurs after setting
+\ up the interrupt but before stopping your task, it won't wake up.
+\ 
+\ The correct way to handle this is to prepare for stopping
+\ *before* checking the condition:
+\
+\   need-some-state? if
+\     will-stop setup-statechange-irq pause
+\   then
+
+: will-stop ( -- ) \ Stop current task at next pause
+  false task-state ! inline ;
+: wont-stop ( -- ) \ Do not stop current task at next pause
+  true task-state ! inline ;
+

--- a/explore/1608-forth/flib/stm32f1/i2c.fs
+++ b/explore/1608-forth/flib/stm32f1/i2c.fs
@@ -38,7 +38,7 @@ $40005800 constant I2C2
 : i2c-busy?   ( -- b) I2C1-SR2 h@ 1 bit and 0<> ;
 
 \ Init and reset I2C. Probably overkill. TODO simplify
-: i2c-init
+: i2c-init ( -- )
   \ Reset I2C1
   APB1-RST-I2C1 RCC-APB1RSTR bis!
   APB1-RST-I2C1 RCC-APB1RSTR bic!
@@ -96,7 +96,7 @@ $40005800 constant I2C2
   10 bit I2C1-CR1 hbis!    \ ACK enable
 
   \ Wait for bus to initialize
-  i2c.timeout @ begin 1- dup 0= i2c-busy? 0= or until
+  i2c.timeout @ begin 1- dup 0= i2c-busy? 0= or until drop
 ;
 
 \ debugging


### PR DESCRIPTION
For working with interrupt handlers, you need a separate word for "I'm going to stop but let me check the flag once again just to be safe".
IMHO, previous/insert/remove as words are too generic.

Added some documentation to multi.fs to explain how to work with interrupts. This should also explain the previous change.

Not allowing for clock stretching is bad for your chip's health.

Leaving a nak flag on the stack only sometimes is bad for the programmer's health. ;-)