### PR TITLE
Add i2c-EV8_2, fixes #69

### DIFF
--- a/explore/1608-forth/flib/stm32f1/i2c.fs
+++ b/explore/1608-forth/flib/stm32f1/i2c.fs
@@ -162,6 +162,7 @@ $40005800 constant I2C2
 : i2c-EV8_1 i2c-SR1-TxE  i2c-SR1-wait ;
 : i2c-EV7   i2c-SR1-RxNE i2c-SR1-wait ;
 : i2c-EV7_2 i2c-SR1-BTF  i2c-SR1-wait ;
+: i2c-EV8_2 i2c-EV8_1 i2c-EV7_2 ;                    \ Empty outgoing data
 
 \ Compatibility layer
 
@@ -204,8 +205,10 @@ $40005800 constant I2C2
         0 i2c.needstop !
       endof
       0 of                      ( cnt = 0, probe only )
-        i2c-nak? i2c-AF-0 i2c-stop
-        0 i2c.needstop !
+	i2c-EV8_2                  \ Flush outbound data first
+        i2c-nak? i2c-AF-0          \ push nak flag & clear it
+	i2c-stop
+        0 i2c.needstop !	
       endof
       ( default: n > 2 )
         i2c-start  \ set start bit,  wait for start condition


### PR DESCRIPTION
I'll submit this PR, which fixes #69. The last byte of multibyte transfers was being clobbered by `0 i2c-xfer`. That is working correctly now, and gets my Oled to light up and respond to commands like `show-logo` and `demo`.

- I still have issues with the oled: only the odd rows are lighting up and everything is stretched out in the vertical direction. This is apparently a common issue, and should be easily fixed?
- In testing this patch, I uncovered several issues in multibyte reads using `i2c>`. I'll start a new issue for that.