### PR TITLE
Add more modules to flib/stm32f4

### DIFF
--- a/explore/1608-forth/flib/stm32f4/adc.fs
+++ b/explore/1608-forth/flib/stm32f4/adc.fs
@@ -1,0 +1,47 @@
+\ simple one-shot ADC
+
+$40012000 constant ADC1
+    ADC1 $00 + constant ADC1-SR
+    ADC1 $04 + constant ADC1-CR1
+    ADC1 $08 + constant ADC1-CR2
+    ADC1 $0C + constant ADC1-SMPR1
+    ADC1 $10 + constant ADC1-SMPR2
+    ADC1 $2C + constant ADC1-SQR1
+    ADC1 $30 + constant ADC1-SQR2
+    ADC1 $34 + constant ADC1-SQR3
+    ADC1 $4C + constant ADC1-DR
+    ADC1 $304 + constant ADC-CCR
+
+: adc-calib ( -- )  \ not needed on F4, retained for compatibility
+  ;
+
+: adc-once ( -- u )  \ read ADC value once
+  0 bit ADC1-CR2 bis!  \ set ADON to start ADC
+  30 bit ADC1-CR2 bis! \ set SWSTART to begin conversion
+  begin 1 bit ADC1-SR bit@ until  \ wait until EOC set
+  ADC1-DR @ ;
+
+: adc-init ( -- )  \ initialise ADC
+  8 bit RCC-APB2ENR bis!  \ set ADC1EN
+  23 bit ADC-CCR bis! \ set TSVREFE for vRefInt use
+   0 bit ADC1-CR2 bis!  \ set ADON to enable ADC
+  \ 7.5 cycles sampling time is enough for 18 kΩ to ground, measures as zero
+  \ even 239.5 cycles is not enough for 470 kΩ, it still leaves 70 mV residual
+  %111 21 lshift ADC1-SMPR1 bis! \ set SMP17 to 239.5 cycles for vRefInt
+  %110110110 ADC1-SMPR2 bis! \ set SMP0/1/2 to 71.5 cycles, i.e. 83 µs/conv
+  adc-once drop ;
+
+: adc# ( pin -- n )  \ convert pin number to adc index
+\ nasty way to map the pins (a "c," table offset lookup might be simpler)
+\   PA0..7 => 0..7, PB0..1 => 8..9, PC0..5 => 10..15
+  dup io# swap  io-port ?dup if shl + 6 + then ;
+
+: adc ( pin -- u )  \ read ADC value
+\ IMODE-ADC over io-mode!
+\ nasty way to map the pins (a "c," table offset lookup might be simpler)
+\   PA0..7 => 0..7, PB0..1 => 8..9, PC0..5 => 10..15
+  adc# ADC1-SQR3 !  adc-once ;
+
+: adc-vcc ( -- mv )  \ return estimated Vcc, based on 1.2V internal bandgap
+  3300 1200  17 ADC1-SQR3 !  adc-once  */ ;
+

--- a/explore/1608-forth/flib/stm32f4/io.fs
+++ b/explore/1608-forth/flib/stm32f4/io.fs
@@ -51,8 +51,10 @@ $40020000 constant GPIO-BASE
 
 %0001010 constant OMODE-AF-PP  \ alternate function, push-pull
 %1001010 constant OMODE-AF-OD  \ alternate function, open drain
+%1011010 constant OMODE-AF-OD-HIGH  \ alternate function, open drain, pull up
 %0000110 constant OMODE-PP     \ output, push-pull
 %1000110 constant OMODE-OD     \ output, open drain
+%1010110 constant OMODE-OD-HIGH  \ output, open drain, pull up
 
 -2 constant OMODE-WEAK  \ add to OMODE-* for 400 KHz iso 10 MHz drive
 -1 constant OMODE-SLOW  \ add to OMODE-* for 2 MHz iso 10 MHz drive

--- a/explore/1608-forth/flib/stm32f4/spi.fs
+++ b/explore/1608-forth/flib/stm32f4/spi.fs
@@ -1,0 +1,38 @@
+\ hardware SPI driver
+
+[ifndef] ssel  PA4 variable ssel  [then]  \ can be changed at run time
+[ifndef] SCLK  PA5 constant SCLK  [then]
+[ifndef] MISO  PA6 constant MISO  [then]
+[ifndef] MOSI  PA7 constant MOSI  [then]
+
+$40013000 constant SPI1
+     SPI1 $0 + constant SPI1-CR1
+     SPI1 $4 + constant SPI1-CR2
+     SPI1 $8 + constant SPI1-SR
+     SPI1 $C + constant SPI1-DR
+
+: spi. ( -- )  \ display SPI hardware registers
+  cr ." CR1 " SPI1-CR1 @ h.4
+    ."  CR2 " SPI1-CR2 @ h.4
+     ."  SR " SPI1-SR @ h.4 ;
+
+: +spi ( -- ) ssel @ ioc! ;  \ select SPI
+: -spi ( -- ) ssel @ ios! ;  \ deselect SPI
+
+: >spi> ( c -- c )  \ hardware SPI, 8 bits
+  SPI1-DR !  begin SPI1-SR @ 1 and until  SPI1-DR @ ;
+
+\ single byte transfers
+: spi> ( -- c ) 0 >spi> ;  \ read byte from SPI
+: >spi ( c -- ) >spi> drop ;  \ write byte to SPI
+
+: spi-init ( -- )  \ set up hardware SPI
+  OMODE-PP ssel @ io-mode! -spi
+  OMODE-AF-PP SCLK io-mode!
+  IMODE-FLOAT MISO io-mode!
+  OMODE-AF-PP MOSI io-mode!
+  12 bit RCC-APB2ENR bis!  \ set SPI1EN
+  %0000000001010100 SPI1-CR1 !  \ clk/8, i.e. 9 MHz, master
+  SPI1-SR @ drop  \ appears to be needed to avoid hang in some cases
+  2 bit SPI1-CR2 bis!  \ SS output enable
+;

--- a/explore/1608-forth/flib/stm32f4/spi2.fs
+++ b/explore/1608-forth/flib/stm32f4/spi2.fs
@@ -1,0 +1,38 @@
+\ hardware SPI driver, 2nd device
+
+[ifndef] ssel2  PB12 variable ssel2  [then]  \ can be changed at run time
+[ifndef] SCLK2  PB13 constant SCLK2  [then]
+[ifndef] MISO2  PB14 constant MISO2  [then]
+[ifndef] MOSI2  PB15 constant MOSI2  [then]
+
+$40003800 constant SPI2
+     SPI2 $0 + constant SPI2-CR1
+     SPI2 $4 + constant SPI2-CR2
+     SPI2 $8 + constant SPI2-SR
+     SPI2 $C + constant SPI2-DR
+
+: spi2. ( -- )  \ display SPI hardware registers
+  cr ." CR1 " SPI2-CR1 @ h.4
+    ."  CR2 " SPI2-CR2 @ h.4
+     ."  SR " SPI2-SR @ h.4 ;
+
+: +spi2 ( -- ) ssel2 @ ioc! ;  \ select SPI
+: -spi2 ( -- ) ssel2 @ ios! ;  \ deselect SPI
+
+: >spi2> ( c -- c )  \ hardware SPI, 8 bits
+  SPI2-DR !  begin SPI2-SR @ 1 and until  SPI2-DR @ ;
+
+\ single byte transfers
+: spi2> ( -- c ) 0 >spi2> ;  \ read byte from SPI
+: >spi2 ( c -- ) >spi2> drop ;  \ write byte to SPI
+
+: spi2-init ( -- )  \ set up hardware SPI
+  OMODE-PP ssel2 @ io-mode! -spi2
+  OMODE-AF-PP SCLK2 io-mode!
+  IMODE-FLOAT MISO2 io-mode!
+  OMODE-AF-PP MOSI2 io-mode!
+  14 bit RCC-APB1ENR bis!  \ set SPI2EN
+  %0000000001001100 SPI2-CR1 !  \ clk/4, i.e. 9 MHz, master
+  SPI2-SR @ drop  \ appears to be needed to avoid hang in some cases
+  2 bit SPI2-CR2 bis!  \ SS output enable
+;

--- a/explore/1608-forth/flib/stm32f4/uart2-irq.fs
+++ b/explore/1608-forth/flib/stm32f4/uart2-irq.fs
@@ -1,0 +1,38 @@
+\ interrupt-based USART2 with input ring buffer
+\ needs ring.fs,cond.fs,stm32f4/io.h
+
+$40004400 constant USART2
+   USART2 $00 + constant USART2-SR
+   USART2 $04 + constant USART2-DR
+   USART2 $08 + constant USART2-BRR
+   USART2 $0C + constant USART2-CR1
+\  USART2 $10 + constant USART2-CR2
+\  USART2 $14 + constant USART2-CR3
+\  USART2 $18 + constant USART2-GPTR
+
+128 4 + buffer: uart-ring
+
+: uart-irq-handler ( -- )  \ handle the USART receive interrupt
+  USART2-DR @  \ will drop input when there is no room left
+  uart-ring dup ring? if >ring else 2drop then ;
+
+$E000E104 constant NVIC-EN1R \ IRQ 32 to 63 Set Enable Register
+
+: uart-irq-init ( -- )  \ initialise the USART2 using a receive ring buffer
+  uart-ring 128 init-ring
+  ['] uart-irq-handler irq-usart2 !
+  6 bit NVIC-EN1R !  \ enable USART2 interrupt 38
+  5 bit USART2-CR1 bis!  \ set RXNEIE
+;
+
+: uart-irq-key? ( -- f )  \ input check for interrupt-driven ring buffer
+  pause uart-ring ring# 0<> ;
+: uart-irq-key ( -- c )  \ input read from interrupt-driven ring buffer
+  begin uart-irq-key? until  uart-ring ring> ;
+
+: init ( -- )
+  [ifdef] init init [then] \ run previous init if it exists
+  uart-irq-init
+  ['] uart-irq-key? hook-key?  !
+  ['] uart-irq-key  hook-key   !
+  ;


### PR DESCRIPTION
Here are some more working stm32f4 versions of the stm32f1 modules.

There's no uart2.fs because F4 mecrisp uses usart2 by default, so it's already initialised at boot.